### PR TITLE
add copy password text and tooltip

### DIFF
--- a/client/src/components/AdminDashboard/CreateUserModal.tsx
+++ b/client/src/components/AdminDashboard/CreateUserModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC, FormEvent, useState } from 'react';
 import { ROLES } from '../../app/constants';
-import { AiOutlineReload } from 'react-icons/ai';
+import { AiOutlineReload, AiOutlineCopy } from 'react-icons/ai';
 import { useAppDispatch } from '../../app/hooks';
 import { CreateUserType } from '../../app/typescriptTypes';
 import { generatePassword } from '../../app/generatePassword';
@@ -43,6 +43,51 @@ const CreateUserModal: FC<Props> = (props) => {
             [e.currentTarget.name]: e.currentTarget.value,
         });
     };
+    const copyPasswordToClipboard = (): void => {
+        const element = document.getElementById('password') as HTMLInputElement;
+        const tooltip = document.getElementById('copyPassTooltip');
+        if (element && tooltip) {
+            element.select();
+            element.setSelectionRange(0, 99999); // <- for mobile browsers
+            navigator.clipboard.writeText(element.value);
+
+            tooltip.innerText = `Copied: ${element.value}`;
+            tooltip.style.color = '#333';
+            tooltip.style.backgroundColor = '#07c12f';
+        }
+    };
+    const handleGeneratePassword = (): void => {
+        const tooltip = document.getElementById('generatePassTooltip');
+        if (tooltip) {
+            tooltip.innerText = 'Generated Successfully';
+            tooltip.style.backgroundColor = '#07c12f';
+            tooltip.style.color = '#333';
+            setUserDetails({
+                ...userDetails,
+                password: generatePassword(10),
+            });
+        }
+    };
+    const onExitTooltip = (
+        tooltipElementId: 'copyPassTooltip' | 'generatePassTooltip'
+    ): void => {
+        const tooltip = document.getElementById(tooltipElementId);
+        if (tooltip) {
+            tooltip.style.color = '#fff';
+            tooltip.style.backgroundColor = '#555';
+            switch (tooltipElementId) {
+                case 'copyPassTooltip':
+                    tooltip.innerText = 'Copy Password';
+                    break;
+                case 'generatePassTooltip':
+                    tooltip.innerText = 'Generate Password';
+                    break;
+                default:
+                    break;
+            }
+        }
+    };
+
     const onSubmit = async (e: any) => {
         e.preventDefault();
         try {
@@ -56,8 +101,8 @@ const CreateUserModal: FC<Props> = (props) => {
 
             dispatch(getAllUsers());
             props.closeModal(!props.openModal);
-        } catch (err:any) {            
-            throw new Error(err.message)
+        } catch (err: any) {
+            throw new Error(err.message);
         }
     };
     return (
@@ -185,14 +230,32 @@ const CreateUserModal: FC<Props> = (props) => {
 
                             <span
                                 className="generate-password-circle"
-                                onClick={() =>
-                                    setUserDetails({
-                                        ...userDetails,
-                                        password: generatePassword(10),
-                                    })
+                                onClick={handleGeneratePassword}
+                                onMouseLeave={() =>
+                                    onExitTooltip('generatePassTooltip')}
+                            >
+                                <span
+                                    className="tooltip-text"
+                                    id="generatePassTooltip"
+                                >
+                                    Generate Password
+                                </span>
+                                <AiOutlineReload />
+                            </span>
+                            <span
+                                className="copy-password-circle"
+                                onClick={copyPasswordToClipboard}
+                                onMouseLeave={() =>
+                                    onExitTooltip('copyPassTooltip')
                                 }
                             >
-                                <AiOutlineReload />
+                                <span
+                                    className="tooltip-text"
+                                    id="copyPassTooltip"
+                                >
+                                    Copy password
+                                </span>
+                                <AiOutlineCopy />
                             </span>
                         </div>
 

--- a/client/src/components/AdminDashboard/styles/CreateUserModal.scss
+++ b/client/src/components/AdminDashboard/styles/CreateUserModal.scss
@@ -121,7 +121,8 @@
     align-items: center;
 }
 
-.generate-password-circle {
+.generate-password-circle, .copy-password-circle {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -133,9 +134,39 @@
     padding: 3px;
     &:hover {
         cursor: pointer;
+        .tooltip-text {
+            visibility: visible;
+            opacity: 1;
+        }
     }
+    .tooltip-text {
+        visibility: hidden;
+        width: 140px;
+        background-color: #555;
+        color: #fff;
+        text-align: center;
+        border-radius: 6px;
+        padding: 5px;
+        position: absolute;
+        z-index: 1;
+        bottom: 150%;
+        left: 50%;
+        margin-left: -75px;
+        opacity: 0;
+        transition: opacity 0.3s;
+        &::after {
+            content: '';
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            margin-left: -5px;
+            border-width: 5px;
+            border-style: solid;
+            border-color: #555 transparent transparent transparent;
+        }
+    }
+    
 }
-
 .password-input-user-modal {
     min-width: 200px;
     cursor: default;


### PR DESCRIPTION
added a button icon to copy generated password to the end user clipboard.

included a tooltip to show the success

bonus added tooltip for generating password button too
![image](https://user-images.githubusercontent.com/83558840/216706312-4fcbbed5-7f90-4110-9641-d72f63ebdf57.png)
![image](https://user-images.githubusercontent.com/83558840/216706377-bb683db8-944f-487f-9193-2e3cb848a1b7.png)
![image](https://user-images.githubusercontent.com/83558840/216706413-d4d7333b-fa62-483e-8ce7-2c8f9d1e4d2d.png)
![image](https://user-images.githubusercontent.com/83558840/216706504-4587c879-dbbd-4813-ac35-83e47ff5037c.png)

