### PR TITLE
handle undefined api error for login

### DIFF
--- a/client/src/redux/actions/authActions.ts
+++ b/client/src/redux/actions/authActions.ts
@@ -44,7 +44,14 @@ export const signInAction =
         } catch (error: any | AxiosError) {
             if (axiosSrc.isAxiosError(error)) {
                 const axiosErr: AxiosError = error;
-                dispatch(setError(axiosErr.response?.data));
+                const errorMessage =
+                    axiosErr.response?.data === undefined
+                        ? {
+                              message:
+                                  'Unable to fetch Geolocation. Please disable ad blocking for this site to continue.',
+                          }
+                        : axiosErr.response.data;
+                dispatch(setError(errorMessage));
             } else throw new Error(error.message);
         }
     };


### PR DESCRIPTION
Because CORS blocking happens at the client level, capturing the error returns `undefined` since our API hasn't responded. Updated error message output based on the root cause being the GeoLocation request failing when attempting to log in. Since our frontend and API server, both have the origin, we should be fine with handling the expectation of an `undefined` in this scenario
![image](https://user-images.githubusercontent.com/83558840/224799975-a548e44e-396b-4fcf-8e73-4637428c3580.png)
