### PR TITLE
BLMS-1620 Skip adding lights link is overlapping Add Lights Button in modal

### DIFF
--- a/client/src/components/Dashboard/style/dashboard.scss
+++ b/client/src/components/Dashboard/style/dashboard.scss
@@ -66,7 +66,7 @@ button.dashboard-new-project-button:hover {
 
 .overview-icon-main {
     display: flex;
-    width: 40px;
+    width: 20px;
     height: auto;
     color: $primary-bg-light-grey;
 }

--- a/client/src/components/NewRoomModal/style/newRoomModal.css
+++ b/client/src/components/NewRoomModal/style/newRoomModal.css
@@ -131,8 +131,8 @@ label {
 
 .skip-lights-container {
     position: absolute;
-    bottom: 50px;
-    right: 50px;
+    bottom: 30px;
+    right: 10px;
 }
 
 .skip-lights-step {


### PR DESCRIPTION
Moved the "Skip add lights" text so it display's correctly in modal and does not over lap with submit button 